### PR TITLE
Migrate to deb822 format fix

### DIFF
--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -355,7 +355,9 @@ select_mirror() {
 
 		case "$(has_repo main)" in
 			'deb822') sed -ni -e "s|URIs:.*|URIs: $MAIN|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources";;
-			'legacy') echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list;;
+			# There should always be a main repo, so fallback to
+			# creating sources.list unconditionally
+			*) echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list;;
 		esac
 
 		case "${has_repo_x11:-}" in

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -180,7 +180,11 @@ get_mirror_weight() {
 
 select_mirror() {
 	local current_mirror
-	current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*deb[[:space:]]+' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list" ]; then
+		current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*deb[[:space:]]+' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	elif [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources" ]; then
+		current_mirror=$(grep -oE 'https?://[^ ]+' <(grep -m 1 -E '^[[:space:]]*URIs:[[:space:]]+' @TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources) || true)
+	fi
 
 	# Do not update mirror if $TERMUX_PKG_NO_MIRROR_SELECT was set.
 	if [ -n "${TERMUX_PKG_NO_MIRROR_SELECT-}" ] && [ -n "$current_mirror" ]; then
@@ -374,7 +378,11 @@ select_mirror() {
 
 update_apt_cache() {
 	local current_host
-	current_host=$(head -n 1 <(sed -nE -e 's|^\s*deb\s+https?://(.+)\s+stable\s+main$|\1|p' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list" ]; then
+		current_host=$(head -n 1 <(sed -nE -e 's|^\s*deb\s+https?://(.+)\s+stable\s+main$|\1|p' @TERMUX_PREFIX@/etc/apt/sources.list) || true)
+	elif [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources" ]; then
+		current_host=$(head -n 1 <(sed -nE -e 's|^\s*URIs:\s+https?://(.+)$|\1|p' @TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources) || true)
+	fi
 
 	if [ -z "$current_host" ]; then
 		# No primary repositories configured?

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -8,6 +8,7 @@ if [[ "$(id -u)" == "0" ]]; then
 fi
 
 # Setup TERMUX_APP_PACKAGE_MANAGER
+# shellcheck source=/dev/null
 source "@TERMUX_PREFIX@/bin/termux-setup-package-manager" || exit 1
 
 MIRROR_BASE_DIR="@TERMUX_PREFIX@/etc/termux/mirrors"
@@ -112,10 +113,10 @@ has_repo() {
 	# Check if root-repo or x11-repo are installed
 	repo="$1"
 
-	if [ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.list" ]; then
-		echo true
-	else
-		echo false
+	if [[ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.sources" ]]; then
+		echo deb822
+	elif [[ -f "@TERMUX_PREFIX@/etc/apt/sources.list.d/$repo.list" ]]; then
+		echo legacy
 	fi
 }
 
@@ -132,6 +133,7 @@ get_mirror_url() {
 	local -r _has_repo_root="$3"
 
 	unset_mirror_variables
+	# shellcheck source=/dev/null
 	source "$_mirror"
 
 	if [[ -z "${MAIN:-}" ]]; then
@@ -339,24 +341,33 @@ select_mirror() {
 		selected_mirror="${weighted_mirrors[${random_weight}]}"
 	fi
 
-	if [ -n "$selected_mirror" ]; then
-		(
-			unset_mirror_variables
-			source "$selected_mirror"
-			echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list
-			if [[ "$has_repo_x11" == "true" ]]; then
-				echo "deb $X11 x11 main" > @TERMUX_PREFIX@/etc/apt/sources.list.d/x11.list
-			fi
-			if [[ "$has_repo_root" == "true" ]]; then
-				echo "deb $ROOT root stable" > @TERMUX_PREFIX@/etc/apt/sources.list.d/root.list
-			fi
-		)
-	else
+	[[ -z "$selected_mirror" ]] && {
 		# Should not happen unless there is some issue with
 		# the script, or the mirror files
 		echo "Error: None of the mirrors are accessible"
 		exit 1
-	fi
+	}
+
+	(
+		unset_mirror_variables
+		# shellcheck source=/dev/null
+		source "$selected_mirror"
+
+		case "$(has_repo main)" in
+			'deb822') sed -ni -e "s|URIs:.*|URIs: $MAIN|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources";;
+			'legacy') echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list;;
+		esac
+
+		case "${has_repo_x11:-}" in
+			'deb822') sed -ni -e "s|URIs:.*|URIs: $X11|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/x11.sources";;
+			'legacy') echo "deb $X11 x11 main" > @TERMUX_PREFIX@/etc/apt/sources.list.d/x11.list;;
+		esac
+
+		case "${has_repo_root:-}" in
+			'deb822') sed -ni -e "s|URIs:.*|URIs: $ROOT|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/root.sources";;
+			'legacy') echo "deb $ROOT root stable" > @TERMUX_PREFIX@/etc/apt/sources.list.d/root.list;;
+		esac
+	)
 }
 
 update_apt_cache() {
@@ -394,8 +405,8 @@ update_apt_cache() {
 
 force_check_mirror=false
 if [ "${1-}" = "--check-mirror" ]; then
-    force_check_mirror=true
-    shift 1
+	force_check_mirror=true
+	shift 1
 fi
 
 if [[ $# = 0 || $(echo "$1" | grep "^h") ]]; then
@@ -419,7 +430,7 @@ case "$TERMUX_APP_PACKAGE_MANAGER" in
 			rei*) apt install --reinstall "$@";;
 			se*) select_mirror; update_apt_cache; apt search "$@";;
 			un*|rem*|rm|del*) apt remove "$@";;
-                        upd*) select_mirror; apt update;;
+			upd*) select_mirror; apt update;;
 			up|upg*) select_mirror; apt update; apt full-upgrade "$@";;
 			*) ERROR=true;;
 		esac;;
@@ -435,7 +446,7 @@ case "$TERMUX_APP_PACKAGE_MANAGER" in
 			rei*) pacman -S "$@";;
 			se*) pacman -Sys "$@";;
 			un*|rem*|rm|del*) pacman -Rcns "$@";;
-                        upd*) pacman -Sy "$@";;
+			upd*) pacman -Sy "$@";;
 			up|upg*) pacman -Syu "$@";;
 			*) ERROR=true;;
 		esac;;

--- a/scripts/pkg.in
+++ b/scripts/pkg.in
@@ -354,19 +354,19 @@ select_mirror() {
 		source "$selected_mirror"
 
 		case "$(has_repo main)" in
-			'deb822') sed -ni -e "s|URIs:.*|URIs: $MAIN|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources";;
+			'deb822') sed -i -e "s|URIs:.*|URIs: $MAIN|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/main.sources";;
 			# There should always be a main repo, so fallback to
 			# creating sources.list unconditionally
 			*) echo "deb $MAIN stable main" > @TERMUX_PREFIX@/etc/apt/sources.list;;
 		esac
 
 		case "${has_repo_x11:-}" in
-			'deb822') sed -ni -e "s|URIs:.*|URIs: $X11|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/x11.sources";;
+			'deb822') sed -i -e "s|URIs:.*|URIs: $X11|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/x11.sources";;
 			'legacy') echo "deb $X11 x11 main" > @TERMUX_PREFIX@/etc/apt/sources.list.d/x11.list;;
 		esac
 
 		case "${has_repo_root:-}" in
-			'deb822') sed -ni -e "s|URIs:.*|URIs: $ROOT|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/root.sources";;
+			'deb822') sed -i -e "s|URIs:.*|URIs: $ROOT|" "@TERMUX_PREFIX@/etc/apt/sources.list.d/root.sources";;
 			'legacy') echo "deb $ROOT root stable" > @TERMUX_PREFIX@/etc/apt/sources.list.d/root.list;;
 		esac
 	)

--- a/scripts/termux-info.in
+++ b/scripts/termux-info.in
@@ -44,30 +44,22 @@ updates() {
 }
 
 repo_subscriptions_apt() {
-	local main_sources
-	main_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "@TERMUX_PREFIX@/etc/apt/sources.list")
+	local apt_dir='@TERMUX_PREFIX@/etc/apt'
 
-	if [ -n "$main_sources" ]; then
-		echo "# sources.list"
-		echo "$main_sources"
-	fi
+	local filename source_entry repo_package sources_type
+	for filename in $apt_dir/sources.list{,.d/*}; do
+		[[ -f "$filename" ]] || continue
+		case "$filename" in
+			*.sources) sources_type="deb822";;
+			*.list)    sources_type="legacy";;
+			*) continue;; # Not a valid source type, skip
+		esac
+		source_entry="$(<"$filename")"
+		repo_package=$(dpkg -S "$filename" 2>/dev/null | cut -d : -f 1)
 
-	if [ -d "@TERMUX_PREFIX@/etc/apt/sources.list.d" ]; then
-		local filename repo_package supl_sources
-		while read -r filename; do
-			repo_package=$(dpkg -S "$filename" 2>/dev/null | cut -d : -f 1)
-			supl_sources=$(grep -E '^[[:space:]]*deb[[:space:]]' "$filename")
-
-			if [ -n "$supl_sources" ]; then
-				if [ -n "$repo_package" ]; then
-					echo "# $repo_package (sources.list.d/$(basename "$filename"))"
-				else
-					echo "# sources.list.d/$(basename "$filename")"
-				fi
-				echo "$supl_sources"
-			fi
-		done < <(find "@TERMUX_PREFIX@/etc/apt/sources.list.d" -maxdepth 1 ! -type d)
-	fi
+		echo "# ${repo_package:+"$repo_package ("}${filename/${apt_dir}\/}${repo_package:+")"} [${sources_type}]"
+		echo "$source_entry"
+	done
 }
 
 repo_subscriptions_pacman() {


### PR DESCRIPTION
* Fix sed outputting nothing (remove -n)
* Support finding current_mirror with main.sources as well (to silence a warning: `grep: /data/data/com.termux/files/usr/etc/apt/sources.list: No such file or directory`)
* Fix so that legacy main repo replacement works (has_repo main checks for $PREFIX/etc/apt/sources.list.d/main.sources, which will not exist in legacy case)